### PR TITLE
Remove unnecessary useState

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,18 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 const useKey = (
   targetKey: string,
   onChange: (pressed: boolean, event: KeyboardEvent) => void
-): boolean => {
-  const [keyPressed, setKeyPressed] = useState<boolean>(false);
-
+) => {
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === targetKey) {
-        setKeyPressed(true);
         onChange(true, event);
       }
     };
 
     const handleKeyUp = (event: KeyboardEvent) => {
       if (event.key === targetKey) {
-        setKeyPressed(false);
         onChange(false, event);
       }
     };
@@ -29,8 +25,6 @@ const useKey = (
       window.removeEventListener("keyup", handleKeyUp);
     };
   }, [onChange, targetKey]);
-
-  return keyPressed;
 };
 
 export default useKey;


### PR DESCRIPTION
The functionality of this hook does not depend on a key pressed state, and would be more flexibly handled by the component it's used in. 